### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ easy-to-use [Jingo](https://github.com/jbalogh/jingo) adapter.
 
 ## Installation
 
-Download via pip [![pip badge](https://pypip.in/version/django-model-urls/badge.svg)](https://pypi.python.org/pypi/django-model-urls/)
+Download via pip [![pip badge](https://img.shields.io/pypi/v/django-model-urls.svg)](https://pypi.python.org/pypi/django-model-urls/)
 
 ```bash
 pip install django-model-urls


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20django-model-urls))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `django-model-urls`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.